### PR TITLE
Running apt-get update and install on same line.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@
 FROM debian:stretch
 LABEL maintainer="Luong Bui"
 
-RUN apt-get update
-RUN apt-get -y install g++-multilib git python curl build-essential debhelper zip
+RUN apt-get update && apt-get -y install g++-multilib git python curl build-essential debhelper zip
 
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ENV PATH="/depot_tools:${PATH}"


### PR DESCRIPTION
This is to avoid Docker to cache the update command hence installing with a cached update.
