### PR TITLE
Release 1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@
 FROM debian:stretch
 LABEL maintainer="Luong Bui"
 
-RUN apt-get update
-RUN apt-get -y install g++-multilib git python curl build-essential debhelper zip
+RUN apt-get update && apt-get -y install g++-multilib git python curl build-essential debhelper zip
 
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ENV PATH="/depot_tools:${PATH}"

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-##How to run
+## How to run
 
 Simply build the docker image:
 ```
@@ -14,7 +14,7 @@ docker build --build-arg dart_version=VERSION .
 
 Bear in mind that I made this Dockerfile mainly to build 1.24.3 which is the last known version for me that is buildable for armv6.
 
-##How to retrieve the built dart sdk
+## How to retrieve the built dart sdk
 
 The created image will contain a zip file with the dart binaries. The zip file will be at the root (/) folder of the image.
 
@@ -31,7 +31,7 @@ unzip dart-sdk.zip
 scp -r dart-sdk user@raspberry.zero.ip:/path/remote/folder 
 ```
 
-##How to test the sdk
+## How to test the sdk
 
 In the `test` folder of this repo you can find some very simple dart file.
 


### PR DESCRIPTION
Run apt-get update and install on the same line to avoid installing using a cached apt.
