### PR TITLE
Release 1.0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+
+  build:
+
+    docker:
+      - image: debian:stretch
+
+    environment:
+      DOCKER_REPO: "luongbui/dart-vm_armv6"
+      TAG: "2.0.0-dev.55.0"
+
+    steps:
+
+      - run:
+          name: Install Docker
+          command: |
+            apt-get update
+            apt-get -y install apt-transport-https dirmngr
+            echo 'deb https://apt.dockerproject.org/repo debian-stretch main' >> /etc/apt/sources.list
+            apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys F76221572C52609D
+            apt-get update
+            apt-get -y install docker-engine
+
+      - checkout
+
+      - setup_remote_docker
+
+      - run:
+          name: Build Docker image with dart-vm binary
+          command: |
+            docker build  --build-arg dart_version=$TAG --tag $DOCKER_REPO:$TAG .
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push $DOCKER_REPO:$TAG
+
+      - run:
+          name: Upload Docker image to Hub
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push $DOCKER_REPO:$TAG

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .gitignore
+.circleci
 README.md
 test/
 


### PR DESCRIPTION
Use CircleCI to build the image and upload it to Docker Hub.

Tag the image with the Dart VM version.
